### PR TITLE
Add query event type definitions

### DIFF
--- a/.changeset/five-otters-attack.md
+++ b/.changeset/five-otters-attack.md
@@ -2,4 +2,6 @@
 '@powersync/mysql-zongji': minor
 ---
 
-Added type definitions for binlog query event
+- Added type definitions for binlog query event
+- Added the ability to provide a table filter function for including/excluding binlog events
+- Updated Zongji class type definition

--- a/.changeset/five-otters-attack.md
+++ b/.changeset/five-otters-attack.md
@@ -1,0 +1,5 @@
+---
+'@powersync/mysql-zongji': minor
+---
+
+Added type definitions for binlog query event

--- a/.github/workflows/dev-packages.yaml
+++ b/.github/workflows/dev-packages.yaml
@@ -4,6 +4,11 @@ name: Create Dev Release
 
 on:
   push:
+    branches:
+      - '**'
+      - '!main' # excludes main, this is handled by changesets
+    tags-ignore:
+      - '**'
 
 jobs:
   publish:

--- a/index.js
+++ b/index.js
@@ -325,10 +325,14 @@ ZongJi.prototype._skipSchema = function (database, table) {
   let included =
     includes === undefined ||
     (database in includes &&
-      (includes[database] === true || (Array.isArray(includes[database]) && includes[database].indexOf(table) > -1)));
+      (includes[database] === true ||
+        (Array.isArray(includes[database]) && includes[database].indexOf(table) > -1) ||
+        (typeof includes[database] === 'function' && includes[database](table))));
   let excluded =
     database in excludes &&
-    (excludes[database] === true || (Array.isArray(excludes[database]) && excludes[database].indexOf(table) > -1));
+    (excludes[database] === true ||
+      (Array.isArray(excludes[database]) && excludes[database].indexOf(table) > -1) ||
+      (typeof excludes[database] === 'function' && excludes[database](table)));
 
   return excluded || !included;
 };

--- a/index.js
+++ b/index.js
@@ -253,8 +253,9 @@ ZongJi.prototype.start = function (options = {}) {
       case 'Rotate':
         if (this.options.filename !== event.binlogName) {
           this.options.filename = event.binlogName;
+          this.emit('binlog', event);
         }
-        break;
+        return;
     }
     this.options.position = event.nextPosition;
     this.emit('binlog', event);

--- a/index.js
+++ b/index.js
@@ -253,9 +253,8 @@ ZongJi.prototype.start = function (options = {}) {
       case 'Rotate':
         if (this.options.filename !== event.binlogName) {
           this.options.filename = event.binlogName;
-          this.emit('binlog', event);
         }
-        return;
+        break;
     }
     this.options.position = event.nextPosition;
     this.emit('binlog', event);

--- a/test/filtering.js
+++ b/test/filtering.js
@@ -45,9 +45,32 @@ tap.test('Unit test', (test) => {
     test.end();
   });
 
+  test.test('FilterFunction includes', (test) => {
+    zongji._filters({
+      includeSchema: { db1: (table) => table === 'just_me' }
+    });
+    test.ok(!zongji._skipSchema('db1', 'just_me'));
+    test.ok(zongji._skipSchema('db2', 'anything_else'));
+    test.ok(zongji._skipSchema('db1', 'not_me'));
+
+    test.end();
+  });
+
   test.test((test) => {
     zongji._filters({
       excludeSchema: { db1: ['not_me'] }
+    });
+
+    test.ok(!zongji._skipSchema('db1', 'anything_else'));
+    test.ok(!zongji._skipSchema('db2', 'anything_else'));
+    test.ok(zongji._skipSchema('db1', 'not_me'));
+
+    test.end();
+  });
+
+  test.test('FilterFunction excludes', (test) => {
+    zongji._filters({
+      excludeSchema: { db1: (table) => table === 'not_me' }
     });
 
     test.ok(!zongji._skipSchema('db1', 'anything_else'));
@@ -79,7 +102,7 @@ tap.test('Unit test', (test) => {
   test.end();
 });
 
-tap.test('Exclue all the schema', (test) => {
+tap.test('Exclude all the schema', (test) => {
   const zongji = new ZongJi(settings.connection);
 
   const eventLog = [];

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -153,13 +153,22 @@ export type BinLogTableMapEvent = BaseBinLogEvent & {
   columnTypes: number[];
 };
 
+export type BinLogQueryEvent = BaseBinLogEvent & {
+  query: string;
+  executionTime: number;
+  errorCode: number;
+  schema: string;
+  statusVars: string;
+};
+
 export type BinLogEvent =
   | BinLogRotationEvent
   | BinLogGTIDLogEvent
   | BinLogXidEvent
   | BinLogRowEvent
   | BinLogRowUpdateEvent
-  | BinLogTableMapEvent;
+  | BinLogTableMapEvent
+  | BinLogQueryEvent;
 
 // @vlasky/mysql Connection
 export interface MySQLConnection {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,5 @@
 import { Socket } from 'net';
+import { EventEmitter } from 'events';
 
 /**
  *  The types described here were added on an adhoc basis based on requirements in the Powersync Service.
@@ -177,7 +178,7 @@ export interface MySQLConnection {
   query(sql: string, callback: (error: any, results: any, fields: any) => void): void;
 }
 
-export declare class ZongJi {
+export declare class ZongJi extends EventEmitter {
   stopped: boolean;
   connection: MySQLConnection;
   constructor(options: ZongjiOptions);
@@ -186,6 +187,4 @@ export declare class ZongJi {
   stop(): void;
   pause(): void;
   resume(): void;
-
-  on(type: 'binlog' | string, callback: (event: BinLogEvent) => void): void;
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -21,10 +21,11 @@ export type ZongjiOptions = {
 
 /**
  *  Record specifying a database and specific tables. ie. ['MyDatabase']: ['table1', 'table2']
- *  Alternatively specifying true will include all tables in the database.
+ *  OR a filter function that returns true for tables that should be included
+ *  OR specifying true will include all tables in the database.
  */
 interface DatabaseFilter {
-  [databaseName: string]: string[] | true;
+  [databaseName: string]: string[] | true | ((table: string) => boolean);
 }
 
 export type StartOptions = {


### PR DESCRIPTION
For PowerSync we want to automatically respond to schema changes on the tables subscribed to for binlog events.
Unfortunately tablemap events themselves are not enough to catch all schema changes, but parsing the binlog query events is more reliable. This changeset adds the type definitions for the query events.

It also adds the ability to specify the table include/exclude as a filter function. This is more dynamically flexible than the existing table list.