### PR TITLE
Emit schema mismatch errors

### DIFF
--- a/.changeset/calm-camels-slide.md
+++ b/.changeset/calm-camels-slide.md
@@ -1,0 +1,5 @@
+---
+'@powersync/mysql-zongji': minor
+---
+
+Emit error when an unrecoverable schema change was encountered

--- a/index.js
+++ b/index.js
@@ -248,9 +248,12 @@ ZongJi.prototype.start = function (options = {}) {
             try {
               event.updateColumnInfo();
             } catch (error) {
-              const schemaError = new Error('Historical event received with unrecoverable schema changes.', {
-                cause: error
-              });
+              const schemaError = new Error(
+                `Event received for table <${event.tableName}> that does not match the current schema.`,
+                {
+                  cause: error
+                }
+              );
               this.emit('error', schemaError);
               return;
             }

--- a/index.js
+++ b/index.js
@@ -132,7 +132,9 @@ ZongJi.prototype._fetchTableInfo = function (tableMapEvent, next) {
     if (rows.length === 0) {
       this.emit(
         'error',
-        new Error('Insufficient permissions to access: ' + tableMapEvent.schemaName + '.' + tableMapEvent.tableName)
+        new Error(
+          `Insufficient permissions to access [${tableMapEvent.schemaName}.${tableMapEvent.tableName}], or the table has been dropped.`
+        )
       );
       // This is a fatal error, no additional binlog events will be
       // processed since next() will never be called
@@ -249,7 +251,7 @@ ZongJi.prototype.start = function (options = {}) {
               event.updateColumnInfo();
             } catch (error) {
               const schemaError = new Error(
-                `Event received for table <${event.tableName}> that does not match the current schema.`,
+                `Event received for table [${event.schemaName}.${event.tableName}] that does not match its current schema.`,
                 {
                   cause: error
                 }

--- a/index.js
+++ b/index.js
@@ -248,8 +248,10 @@ ZongJi.prototype.start = function (options = {}) {
             try {
               event.updateColumnInfo();
             } catch (error) {
-              const error = new Error('Historical event received with unrecoverable schema changes.', { cause: err });
-              this.emit('error', error);
+              const schemaError = new Error('Historical event received with unrecoverable schema changes.', {
+                cause: err
+              });
+              this.emit('error', schemaError);
               return;
             }
             this.emit('binlog', event);

--- a/index.js
+++ b/index.js
@@ -249,7 +249,7 @@ ZongJi.prototype.start = function (options = {}) {
               event.updateColumnInfo();
             } catch (error) {
               const schemaError = new Error('Historical event received with unrecoverable schema changes.', {
-                cause: err
+                cause: error
               });
               this.emit('error', schemaError);
               return;

--- a/lib/common.js
+++ b/lib/common.js
@@ -481,6 +481,11 @@ exports.readMysqlValue = function (
       lengthSize = column.metadata['length_size'];
       size = parser.parseUnsignedNumber(lengthSize);
       buffer = parser.parseBuffer(size);
+      // // Return raw WKB value. First 4 bytes are the SRID which we ignore
+      // console.log(`Parsing Geometry value size: ${size} buffer size: ${buffer.length}`);
+      // result = new Uint8Array(buffer.slice(4));
+      // console.log(`Parsed Geometry value size: ${result}`);
+
       result = parseGeometryValue(buffer);
       break;
     case MysqlTypes.DATE:

--- a/lib/common.js
+++ b/lib/common.js
@@ -481,11 +481,6 @@ exports.readMysqlValue = function (
       lengthSize = column.metadata['length_size'];
       size = parser.parseUnsignedNumber(lengthSize);
       buffer = parser.parseBuffer(size);
-      // // Return raw WKB value. First 4 bytes are the SRID which we ignore
-      // console.log(`Parsing Geometry value size: ${size} buffer size: ${buffer.length}`);
-      // result = new Uint8Array(buffer.slice(4));
-      // console.log(`Parsed Geometry value size: ${result}`);
-
       result = parseGeometryValue(buffer);
       break;
     case MysqlTypes.DATE:


### PR DESCRIPTION
TableMap events containing some schema information are sent before every row event on the BinLog.  The tablemap event briefly describes the schema of the table for the following row event. Unfortunately this description does not include the column names for the table. Instead this info is queried from the DB directly.

This poses a problem when older row events are received where the table schema at that point in time does not match the current schema. In such a case it may be impossible to consolidate the schema changes and the listener should emit the error so it can be handled downstream.

These changes ensures we emit these errors instead of crashing the listener.
