### PR TITLE
Add missing `startAtEnd` option definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -57,6 +57,11 @@ export type StartOptions = {
    *  Unique server ID for this replication client.
    */
   serverId?: number;
+
+  /**
+   * Pass `true` to only emit binlog events that occur after ZongJi's instantiation.
+   */
+  startAtEnd?: boolean;
 };
 
 export type ColumnSchema = {


### PR DESCRIPTION
The `startAtEnd` flag is missing in the `StartOptions` type definition.